### PR TITLE
ci: add trusted PyPI publishing workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,35 @@
+name: Publish to PyPI
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  pypi-publish:
+    name: Upload release to PyPI
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/call-a-human-mcp
+    permissions:
+      id-token: write
+    steps:
+      - name: Check out v0.1.0
+        uses: actions/checkout@v4
+        with:
+          ref: v0.1.0
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+
+      - name: Build distributions
+        run: |
+          python -m pip install --upgrade build
+          python -m build
+
+      - name: Publish distributions to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
## Summary

Add a tokenless PyPI publishing workflow using GitHub OIDC and the official PyPA publishing action. The one-time manual run builds the already-published v0.1.0 tag, preventing unreviewed branch contents from being uploaded.

## PyPI publisher settings

- Project: call-a-human-mcp
- Owner: nishantmodak
- Repository: call-a-human-mcp
- Workflow: publish.yml
- Environment: pypi

PyPI Trusted Publishing requires id-token: write at the publishing job level.